### PR TITLE
(bugfix): Integer mismatch in Scan.xs

### DIFF
--- a/bindings/perl/xs/Result.xs
+++ b/bindings/perl/xs/Result.xs
@@ -42,7 +42,7 @@ CODE:
 {
   char string[25];
   STRLEN length;
-  length = sprintf(string, "%llu", r->size);
+  length = sprintf(string, "%" PRIu64, r->size);
   RETVAL = newSVpvn(string, length);
 }
 OUTPUT:


### PR DESCRIPTION
This leverages the <inttypes.h> header to help sprintf with the uint64_t type.
Fixes the following warning:
xs/Result.xs: In function 'XS_Media__Scan__Result_size':
xs/Result.xs:45:3: warning: format '%llu' expects argument of type 'long long unsigned int', but argument 3 has type 'uint64_t' [-Wformat]