### PR TITLE
(bugfix): Remove deprecated API calls to libraries

### DIFF
--- a/src/image_gif.c
+++ b/src/image_gif.c
@@ -205,7 +205,7 @@ err:
 
 out:
   if (temp_save.ExtensionBlocks)
-    FreeExtension(&temp_save);
+    GifFreeExtensions(&temp_save.ExtensionBlockCount, &temp_save.ExtensionBlocks );
 
   return ret;
 }

--- a/src/image_jpeg.c
+++ b/src/image_jpeg.c
@@ -192,7 +192,7 @@ static void image_jpeg_buf_src(MediaScanImage *i, MediaScanResult *r) {
   src->jsrc.bytes_in_buffer = buffer_len(src->buf);
   src->jsrc.next_input_byte = (JOCTET *)buffer_ptr(src->buf);
 
-  LOG_DEBUG("Init JPEG buffer src, %d bytes in buffer\n", src->jsrc.bytes_in_buffer);
+  LOG_DEBUG("Init JPEG buffer src, %zu bytes in buffer\n", src->jsrc.bytes_in_buffer);
 }
 
 // Destination manager to copy compressed data to a buffer
@@ -242,7 +242,7 @@ static void buf_dst_mgr_term(j_compress_ptr cinfo) {
   LOG_MEM("destroy JPEG buf @ %p\n", dst->buf);
   free(dst->buf);
 
-  LOG_MEM("buf_dst_mgr_term, copied final %d bytes (total bytes %d)\n", sz, buffer_len(dst->dbuf));
+  LOG_MEM("buf_dst_mgr_term, copied final %zd bytes (total bytes %d)\n", sz, buffer_len(dst->dbuf));
 }
 
 static void image_jpeg_buf_dest(j_compress_ptr cinfo, struct buf_dst_mgr *dst) {

--- a/src/libdlna/profiles.c
+++ b/src/libdlna/profiles.c
@@ -212,13 +212,13 @@ av_profile_get_codecs (AVFormatContext *ctx)
   for (i = 0; i < ctx->nb_streams; i++)
   {
     if (audio_stream == -1 &&
-        ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_AUDIO)
+        ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO)
     {
       audio_stream = i;
       continue;
     }
     else if (video_stream == -1 &&
-             ctx->streams[i]->codec->codec_type == AVMEDIA_TYPE_VIDEO)
+             ctx->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
     {
       video_stream = i;
       continue;
@@ -226,11 +226,15 @@ av_profile_get_codecs (AVFormatContext *ctx)
   }
 
   codecs->as = audio_stream >= 0 ? ctx->streams[audio_stream] : NULL;
-  codecs->ac = audio_stream >= 0 ? ctx->streams[audio_stream]->codec : NULL;
+  if ((audio_stream < 0) || (avcodec_parameters_to_context(codecs->ac, ctx->streams[audio_stream]->codecpar) < 0)) {
+    codecs->ac = NULL;
+  }
   codecs->asid = audio_stream;
 
   codecs->vs = video_stream >= 0 ? ctx->streams[video_stream] : NULL;
-  codecs->vc = video_stream >= 0 ? ctx->streams[video_stream]->codec : NULL;
+  if ((video_stream < 0) || (avcodec_parameters_to_context(codecs->vc, ctx->streams[video_stream]->codecpar) < 0)) {
+    codecs->vc = NULL;
+  }
   codecs->vsid = video_stream;
 
   /* check for at least one video stream and one audio stream in container */
@@ -296,7 +300,7 @@ dlna_guess_media_profile (dlna_t *dlna, const char *filename)
     return NULL;
   }
 
-  if (av_find_stream_info (ctx) < 0)
+  if (avformat_find_stream_info(ctx, NULL) < 0)
   {
     if (dlna->verbosity)
       fprintf (stderr, "can't find stream info\n");
@@ -343,7 +347,7 @@ dlna_guess_media_profile (dlna_t *dlna, const char *filename)
     p = p->next;
   }
 
-  av_close_input_file (ctx);
+  avformat_close_input(&ctx);
   free (codecs);
   return profile;
 }

--- a/src/thread.c
+++ b/src/thread.c
@@ -149,7 +149,7 @@ MediaScanThread *thread_create(void *(*func) (void *), thread_data_type *thread_
     goto fail;
   }
 
-  LOG_DEBUG("Thread %d started\n", t->tid);
+  LOG_DEBUG("Thread %lu started\n", (unsigned long)t->tid);
   goto out;
 
 fail:
@@ -253,7 +253,7 @@ void thread_stop(MediaScanThread *t) {
   if (t->tid.p) {               // XXX needed?
 #endif
 
-    LOG_DEBUG("Waiting for thread %d to stop...\n", t->tid);
+    LOG_DEBUG("Waiting for thread %lu to stop...\n", (unsigned long)t->tid);
     pthread_join(t->tid, NULL);
 
 #ifndef WIN32


### PR DESCRIPTION
This removes most of the deprecated FFMPEG methods, corrects
all the various type mismatches, and fixes lingering giflib
deprecated issues.

Please verify that this works on Solaris. 

TODO: Tackle the deprecation of "codec" within the libdlna stuff.