### PR TITLE
Improve build support for modern OSX

### DIFF
--- a/bindings/perl/Makefile.PL
+++ b/bindings/perl/Makefile.PL
@@ -330,7 +330,7 @@ if ( $^O =~ /sun|solaris/i ) {
 }
 
 push @LDDLFLAGS, $Config{lddlflags};
-unshift @LDDLFLAGS, '-Wl,-Bsymbolic';
+unshift @LDDLFLAGS, '-Wl,-Bsymbolic' unless $^O =~ /Darwin/i;
 
 MAKEFILE:
 

--- a/bindings/perl/hints/darwin.pl
+++ b/bindings/perl/hints/darwin.pl
@@ -1,32 +1,33 @@
 #!/usr/bin/perl
 
 use Config;
+use Cwd;
 
 if ( $Config{myarchname} =~ /i386/ ) {
-    # Read OS version
+    # Should we use the Carbon framework (deprecated since 10.8)
+    my $use_carbon = 1;
+
+   # Read OS version
     my $ver = `sw_vers -productVersion`;
-    my ($osx_ver) = $ver =~ /(10\.(?:[5679]|1[0]))/;
+    my ($osx_ver) = $ver =~ /(10\.(?:[5679]|[1-9][0-9]))/;
     if ($osx_ver eq '10.5' ) {
-        $arch = "-arch i386 -arch ppc -isysroot /Developer/SDKs/MacOSX10.4u.sdk -mmacosx-version-min=10.4";
-    }
-    elsif ( $osx_ver eq '10.6' ) {
-        $arch = '-arch x86_64 -arch i386';
-        if ( -d '/Developer/SDKs/MacOSX10.5.sdk' ) {
-            $arch .= " -isysroot /Developer/SDKs/MacOSX10.5.sdk -mmacosx-version-min=10.5";
+        if ( getcwd() =~ /FSEvents/ ) { # FSEvents is not available in 10.4
+            $arch = "-arch i386 -arch ppc -isysroot /Developer/SDKs/MacOSX10.5.sdk -mmacosx-version-min=10.5";
         }
         else {
-            # 10.5 SDK not installed, use 10.6
-            $arch .= " -isysroot /Developer/SDKs/MacOSX10.6.sdk -mmacosx-version-min=10.6";
+            $arch = "-arch i386 -arch ppc -isysroot /Developer/SDKs/MacOSX10.4u.sdk -mmacosx-version-min=10.4";
         }
+    }
+    elsif ( $osx_ver eq '10.6' ) {
+        $arch = "-arch x86_64 -arch i386 -isysroot /Developer/SDKs/MacOSX10.5.sdk -mmacosx-version-min=10.5";
     }
     elsif ( $osx_ver eq '10.7' ) {
         $arch = "-arch x86_64 -isysroot /Developer/SDKs/MacOSX10.6.sdk -mmacosx-version-min=10.6";
     }
-    elsif ( $osx_ver eq '10.9' ) {
+    elsif ( $osx_ver =~ /10\.\d+/) {
+        # Certain framework deprecations in 10.8 cause issues if 10.7 is used as the min beyond 10.10
+        $use_carbon = 0;
         $arch = "-arch x86_64 -mmacosx-version-min=10.9";
-    }
-    elsif ( $osx_ver eq '10.10' ) {
-        $arch = "-arch x86_64 -mmacosx-version-min=10.10";
     }
     else {
         die "Unsupported OSX version $osx_ver\n";
@@ -43,11 +44,13 @@ if ( $Config{myarchname} =~ /i386/ ) {
     $ldflags  =~ s/-arch\s+\w+//g;
     $lddlflags =~ s/-arch\s+\w+//g;
 
-    # LMS requires some frameworks
-    $ldflags .= " -framework CoreFoundation -framework CoreServices -framework Carbon";
-    $lddlflags .= " -framework CoreFoundation -framework CoreServices -framework Carbon";
+    # LMS requires some frameworks.
+    my $xcode_frameworks = " -framework CoreFoundation -framework CoreServices";
+
+    # Only add the Carbon framework for those versions that need it.
+    $xcode_frameworks .= " -framework Carbon" if ( $use_carbon ) ;
 
     $self->{CCFLAGS} = "$arch -I/usr/include $ccflags";
-    $self->{LDFLAGS} = "$arch -L/usr/lib $ldflags";
-    $self->{LDDLFLAGS} = "$arch -L/usr/lib $lddlflags";
+    $self->{LDFLAGS} = "$arch -L/usr/lib $ldflags $xcode_frameworks";
+    $self->{LDDLFLAGS} = "$arch -L/usr/lib $lddlflags $xcode_frameworks";
 }


### PR DESCRIPTION
These are the changes I had to make inside the libmediascan tarball over in the slimserver-vendor repo. The XCode and clang combination on the test OSX machines doesn't understand (or need) the -Bsymbolic flag. Also, the darwin.pl hints file needs to be modernized, rather than conditionally patched in slimserver-vendor.